### PR TITLE
Excercises in pinning

### DIFF
--- a/episodes/06_pinning.md
+++ b/episodes/06_pinning.md
@@ -65,19 +65,137 @@ Binding / pinning:
 - Mapping of application <-> job resources
 
 
-## Why what how?
-B
-<!-- EPISODE CONTENT HERE -->
+## Motivation
+:::::::::::::::::::::::::: challenge
+## Exercise 
+Case 1: 1 thread per rank
+`mpirun -n 8 ./raytracer -width=512 -height=512 -spp=128 -threads=1 -alloc_mode=3 -png=snowman.png`
+
+Case 2: 2 thread per rank
+`mpirun -n 8 ./raytracer -width=512 -height=512 -spp=128 -threads=2 -alloc_mode=3 -png=snowman.png`
+
+Questions:
+- Do you notice any difference in runtime between the two cases?
+- Is the increase in threads providing a speedup as expected?
+
+::::: solution
+- Observation: The computation times are almost the same.
+- Expected behavior: Increasing threads should ideally reduce runtime.
+- Hypothesis: Additional threads do not contribute.
+::::::::::::::
+::::::::::::::::::::::::::::::::::::
+
+## How to investigate?
+
+You can verify the actual core usage in two ways:
+1. Use `--report-bindings` with `mpirun`
+2. Use `htop`command on the compute node
+
+:::::::::::::::::::::::::: instructor
+## Note: Login to the compute job
+
+This is cluster specific. It can possibly be  done in two ways:
+1. `srun --pty --overlap --jobid=<jobid> /bin/bash`
+2. Check on which node job runs and login to the node via SSH
+:::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::: challenge
+## Exercise
+Follow any one of the option above and run for 2 threads per rank
+`mpirun -n 8 ./raytracer -width=512 -height=512 -spp=128 -threads=2 -alloc_mode=3 -png=snowman.png`
+
+Questions:
+- Did you find any justification for the hypothesis we made?
+
+::::: solution
+Only 8 cores are active instead of 16
+::::::::::::::
+::::::::::::::::::::::::::::::::::::
+
+Explanation:
+
+- Eventhough we requested 2 threads per MPI rank, both threads are pinned to the same core.
+- The second thread waits for the first thread to finish, so no actual thread-level parallelization is achieved.
+
+:::::::::::::::::::::::::: instructor
+## TODO: Show an animation
+- current behavior with overlapping threads on the same core.
+- Expected behavior when threads are pinned to separate cores.
+:::::::::::::::::::::::::::::::::::::
+
+## How to achieve?
+## Exercise: Understanding Process and Thread Binding
+
+In this exercise we will explore how MPI process and thread binding works. We will try binding to **core**, **socket**, and **numa**, and observe timings and bindings.
+
+:::::::::::::::::::::::::: instructor
+## Note
+- This exercise assumes the following hardware setup:  
+  - Dual-socket system (2 sockets, 48 cores per socket, 8 NUMA regions, 96 cores total).  
+  - Each MPI process can use multiple threads (`-threads`) for parallel execution.
+- The idea is to **demonstrate oversubscription** by giving more MPI processes than available sockets or NUMA regions, or by over-allocating threads per domain.  
+- You are free to adjust `-n` and `-threads` based on your cluster.
+:::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::: challenge
+## Exercise
+Case 1: `--bind-to numa`
+`mpirun -n 8 --bind-to numa ./raytracer -width=512 -height=512 -spp=128 -threads=12 -alloc_mode=3 -png=snowman.png`
+
+Case 2: `--bind-to socket`
+`mpirun -n 4 --bind to socket /raytracer -width=512 -height=512 -spp=128 -threads=48 -alloc_mode=3 -png=snowman.png`
+
+Questions:
+- What is difference between Case 1 and Case 2. Any difference in performance? How many workers?
+- How could you adjust process/thread counts to better utilize the hardware in Case 2?
+
+::::: solution
+- MPI and thread pinning is hardware-aware.
+- If the number of processes matches the number of domains (socket or NUMA), then the number of threads should equal the cores per domain to fully utilize the node.
+- No speedup in Case 2: Oversubscription occurs because we requested 4 processes on a system with only 2 sockets.
+- Threads compete for the same cores → OpenMPI queues threads and waits until other processes finish.
+::::::::::::::
+::::::::::::::::::::::::::::::::::::
+
+#Best Practices for MPI Process and Thread Binding
+
+We will use `--bind-to core` (the smallest hardware unit) and `--map-by` to distribute MPI processes across sockets or NUMA or node regions efficiently.
+
+- Best practice: Always bind processes to the smallest unit (core) and spread processes evenly across the available hardware using `--map-by`.
+- Example options:
+  - `--bind-to core` → binds each process to a dedicated core (avoids oversubscription).  
+  - `--map-by socket:PE=<threads>` → spreads given number of threads as a processing element across the socket
+  - `--map-by numa:PE=<threads>` → spreads processes across NUMA domains, assigning `<threads>` cores per process.
+  - similarly `--map-by numa:PE=<threads>`
+
+:::::::::::::::::::::::::: challenge
+## Exercise
+Use the given best practices above for  `-n 8` and `-threads=4`  and answer following questions
+
+Questions:
+- Did you get more workers than you requested?
+
+::::: solution
+No.
+::::::::::::::
+::::::::::::::::::::::::::::::::::::  
 
 
 ## Summary
 
-:::::::::::::::::::::::::: challenge
-## Exercise:
-::::::::::::::::::::::::::::::::::::
+:::::::::::::::::::::::::::::::::::::: key Takeaways
+- **Always check how pinning works**  
+  Use verbose reporting (e.g., `--report-bindings`) to see how MPI processes and threads are mapped to cores and sockets.  
 
-Leading question: Pinning is very specific, but was it really limiting the performance of out application? How can I identify the biggest issue?
+- **Documentation is your friend**  
+  For OpenMPI with `mpirun`, consult the manual: [https://www.open-mpi.org/doc/v4.1/man1/mpirun.1.php](https://www.open-mpi.org/doc/v4.1/man1/mpirun.1.php)  
 
-:::::::::::::::::::::::::::::::::::::: keypoints
-- C
+- **Know your hardware**  
+  Understanding the number of sockets, cores per socket, and NUMA regions on your cluster helps you make effective binding decisions.  
+
+- **Avoid oversubscription**  
+  Assigning more threads or processes than available cores hurts performance — it causes contention and idle waits.  
+
+- **Recommended practice for OpenMPI**  
+  Use `--bind-to core` along with `--map-by` to control placement and threads per process to maximize throughput.
 ::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
This PR adds a new episode focusing on process and thread pinning in MPI jobs. It introduces the concept of pinning, why it matters for performance, and how to investigate and correct cases where oversubscription occurs.

The episode is structured with four scaffolded exercises, each building on the previous:

**Why pinning matters**
- Compare 1 vs. 2 threads per rank and observe that extra threads do not speed up execution.

**Investigating incorrect pinning**
- Use --report-bindings or htop to check actual core usage.
- Show that multiple threads may be pinned to the same core, preventing parallelism.

**Exploring process binding with `--bind-to`**
- Test different binding policies (core, socket, numa).

**Demonstrate oversubscription when requesting more processes than sockets.**
- Highlight why performance does not improve when processes share the same domain.
- Best practices with `--bind-to` and `--map-by`
- Show how to distribute processes across cores, sockets, or NUMA domains.
- Emphasize avoiding oversubscription and aligning requests with hardware topology.

Note:
- I structured this exercise assuming hardware is introduced in the previous exercises.
- I didn’t remove some of the earlier ideas we discussed. Instead, I’ve left them in so we can talk about how to incorporate them more efficiently or seamlessly into the lesson flow.